### PR TITLE
Disable no-param-reassign

### DIFF
--- a/packages/eslint-config-4catalyzer/rules.js
+++ b/packages/eslint-config-4catalyzer/rules.js
@@ -12,6 +12,7 @@ module.exports = {
     ],
     allowSamePrecedence: false,
   }],
+  'no-param-reassign': 'off',
   'no-plusplus': 'off',
   'no-restricted-syntax': ['error',
     'ForInStatement',


### PR DESCRIPTION
I'd like to formally propose we disable this rule.

It exists to guard unexpected behavior related to the `arguments` object, where reassigning a function param also reassigns the value in `arguments`. This is almost never relevant to use because no one uses `arguments` over rest, and use of `arguments` without immediately slicing it to an array is already bad behavior. Also this doesn't actually prevent mutation of the param which is really what you probably want to guard against.

It comes up a often enough that adding pragma's is getting annoying :P