### PR TITLE
Allow underscore dangle after this

### DIFF
--- a/packages/eslint-config-4catalyzer/rules.js
+++ b/packages/eslint-config-4catalyzer/rules.js
@@ -19,6 +19,12 @@ module.exports = {
     'LabeledStatement',
     'WithStatement',
   ],
+  'no-underscore-dangle': ['error', {
+    allow: [],
+    allowAfterThis: true,
+    allowAfterSuper: false,
+    enforceInMethodNames: false,
+  }],
   'no-unused-vars': ['error', {
     vars: 'all',
     args: 'after-used',


### PR DESCRIPTION
cc @jquense

I find myself pragmaing this all the time. Really I think it's fine to use underscores to denote somewhat private methods on classes.