### PR TITLE
disable no-void

### DIFF
--- a/packages/eslint-config-4catalyzer/rules.js
+++ b/packages/eslint-config-4catalyzer/rules.js
@@ -13,6 +13,7 @@ module.exports = {
     allowSamePrecedence: false,
   }],
   'no-plusplus': 'off',
+  'no-void': 'off', // simplify early returns
   'no-restricted-syntax': ['error',
     'ForInStatement',
     // We use iterables, so allow for-of.


### PR DESCRIPTION
ITs a small thing but consistent return leads to slightly more verbose code when calling a method or callback

```js
function FooWhenDone(callback) {
  if (someEarlyReturnCondition) {
    return void callback() 
  }
}
```

vs

```js
function FooWhenDone(callback) {
  if (someEarlyReturnCondition) {
    callback() 
    return
  }
}
```