### PR TITLE
feat: remove no-await-in-loop

### DIFF
--- a/packages/eslint-config-4catalyzer/rules.js
+++ b/packages/eslint-config-4catalyzer/rules.js
@@ -9,6 +9,7 @@ module.exports = {
       ignorePattern: ' // eslint-disable-line ',
     },
   ],
+  'no-await-in-loop': 'off',
   'no-continue': 'off',
   'no-mixed-operators': [
     'error',


### PR DESCRIPTION
w/d/t? I don't know that i've ever found this rule helpful for reminding me i could use `Promise.all` if only b/c we usually use `forEach`/`map` for looping