### PR TITLE
feat: use root mode upwards-optional for jest preset

### DIFF
--- a/packages/jest-preset/index.js
+++ b/packages/jest-preset/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!src/**/*.d.ts'],
   transform: {
-    '^.+\\.(js|jsx|ts|tsx)$': require.resolve('babel-jest'),
+    '^.+\\.(js|jsx|ts|tsx)$': require.resolve('./transforms/javascript'),
     '^.+\\.(scss|less|css)$': require.resolve('./transforms/styles'),
     '^(?!.*\\.(js|jsx|ts|tsx|css|scss|less|json)$)': require.resolve(
       './transforms/file',

--- a/packages/jest-preset/package.json
+++ b/packages/jest-preset/package.json
@@ -16,6 +16,8 @@
     "jest": "^24.8.0"
   },
   "dependencies": {
-    "babel-jest": "^25.0.0"
+    "babel-jest": "^25.0.0",
+    "find-up": "^4.1.0",
+    "find-yarn-workspace-root": "^1.2.1"
   }
 }

--- a/packages/jest-preset/transforms/javascript.js
+++ b/packages/jest-preset/transforms/javascript.js
@@ -1,0 +1,13 @@
+const babelJest = require('babel-jest');
+const findWorkspacesRoot = require('find-yarn-workspace-root');
+
+let isWorkspaces = false;
+try {
+  isWorkspaces = findWorkspacesRoot();
+} catch (err) {
+  /* ignore */
+}
+
+module.exports = babelJest.createTransformer({
+  rootMode: isWorkspaces ? 'upward-optional' : undefined,
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -772,9 +772,16 @@
     "@babel/plugin-transform-react-jsx-self" "^7.8.3"
     "@babel/plugin-transform-react-jsx-source" "^7.8.3"
 
-"@babel/runtime@^7.4.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3":
+"@babel/runtime@^7.4.5", "@babel/runtime@^7.6.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.3.tgz#0811944f73a6c926bb2ad35e918dcc1bfab279f1"
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
+"@babel/runtime@^7.5.5":
+  version "7.7.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.7.5.tgz#4b087f183f5d83647744d4157f66199081d17a00"
+  integrity sha512-UXhClKWTL7/vlYX49kETXti6VbpPJK/pdsIOqUMhUUES/lqThpNTsmC/0aU/IW4uozDUx17axjeqel7SCYF6EQ==
   dependencies:
     regenerator-runtime "^0.13.2"
 
@@ -1938,6 +1945,7 @@
 "@types/fs-extra@^8.0.0":
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-8.0.1.tgz#a2378d6e7e8afea1564e44aafa2e207dadf77686"
+  integrity sha512-J00cVDALmi/hJOYsunyT52Hva5TnJeKP5yd1r+mH/ZU0mbYZflR0Z5kw5kITtKTRYMhm1JMClOFYdHnQszEvqw==
   dependencies:
     "@types/node" "*"
 
@@ -1978,9 +1986,14 @@
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
 
-"@types/node@*", "@types/node@^12.7.1":
+"@types/node@*":
   version "12.12.25"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.25.tgz#792c0afb798f1dd681dce9c4b4c431f7245a0a42"
+
+"@types/node@^12.7.1":
+  version "12.12.14"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.14.tgz#1c1d6e3c75dba466e0326948d56e8bd72a1903d2"
+  integrity sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -4092,6 +4105,7 @@ find-versions@^3.0.0, find-versions@^3.2.0:
 find-workspaces-root@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/find-workspaces-root/-/find-workspaces-root-0.1.0.tgz#0afc33920eca22ad58f87e1e9a49ac97d176c25f"
+  integrity sha512-NIVJ0SB4+BMwN0MXAPYPj5SWgcyYh2bCP2ZJTVW74uSuQ3oWp6hVPfW1HHBYqPuzWbzKbDbwk6kUKXw6Jr+Qsg==
   dependencies:
     "@babel/runtime" "^7.5.5"
     "@types/fs-extra" "^8.0.0"


### PR DESCRIPTION
I think this is ok as a default. My understanding reading: https://babeljs.io/docs/en/configuration is that local babelrc's are always preferred to a config, but this setting means if there is no local babelrc it will look for a root config. Helpful in monorepo's with centralized config