### PR TITLE
Update eslint-plugin-react-hooks peer dependency version

### DIFF
--- a/packages/eslint-config-4catalyzer-react/package.json
+++ b/packages/eslint-config-4catalyzer-react/package.json
@@ -43,7 +43,7 @@
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.14.3",
-    "eslint-plugin-react-hooks": "^1.7.0",
+    "eslint-plugin-react-hooks": "^2.3.0",
     "jest": "^24.8.0",
     "lodash": "^4.17.15",
     "react": "^16.9.0"


### PR DESCRIPTION
Downstream consumers throw this warning:
```warning "eslint-config-4catalyzer-react > eslint-config-airbnb@18.0.1" has incorrect peer dependency "eslint-plugin-react-hooks@^1.7.0".```

Should be OK I think?