### PR TITLE
fix: ensure prepublish scripts are run

### DIFF
--- a/packages/semantic-release-alt-publish-dir/index.js
+++ b/packages/semantic-release-alt-publish-dir/index.js
@@ -1,8 +1,14 @@
 const { promises: fs } = require('fs');
-const { join } = require('path');
 
 const { createAltPublishDir } = require('@4c/file-butler');
 const npmPlugin = require('@semantic-release/npm');
+const execa = require('execa');
+const readPkgUp = require('read-pkg-up');
+
+async function runLifecycle(script, pkg) {
+  if (!pkg.scripts || !pkg.scripts[script]) return;
+  await execa('npm', ['run', script]);
+}
 
 async function verifyConditions(pluginConfig, config) {
   const {
@@ -40,15 +46,23 @@ async function prepare(
   }
 
   logger.log(`Building alternative root package.json`);
-  await createAltPublishDir({ publishDir: pkgRoot });
 
-  const pkgPath = join(cwd, './package.json');
-  // eslint-disable-next-line import/no-dynamic-require
-  const pkg = require(pkgPath);
+  const { path: rootPkgPath, packageJson } = await readPkgUp({ cwd });
+
+  // We run the lifecycle scripts manually to ensure they run in
+  // the package root, not the publish dir
+  await runLifecycle('prepublish', packageJson);
+  await runLifecycle('prepare', packageJson);
+  await runLifecycle('prepublishOnly', packageJson);
+
+  await createAltPublishDir({ publishDir: pkgRoot });
 
   // update the root package since @semantic-release/npm won't;
   logger.log('Updating root package.json file to version %s', version);
-  await fs.writeFile(pkgPath, JSON.stringify({ ...pkg, version }, null, 2));
+  await fs.writeFile(
+    rootPkgPath,
+    JSON.stringify({ ...packageJson, version }, null, 2),
+  );
 }
 
 module.exports = { prepare, verifyConditions };

--- a/packages/semantic-release-alt-publish-dir/package.json
+++ b/packages/semantic-release-alt-publish-dir/package.json
@@ -27,7 +27,9 @@
   },
   "dependencies": {
     "@4c/file-butler": "^4.1.0",
-    "@semantic-release/npm": "^7.0.0"
+    "@semantic-release/npm": "^7.0.0",
+    "execa": "^4.0.0",
+    "read-pkg-up": "^7.0.1"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^5.0.0",

--- a/packages/semantic-release-alt-publish-dir/test/fixtures/package/package.json
+++ b/packages/semantic-release-alt-publish-dir/test/fixtures/package/package.json
@@ -5,6 +5,9 @@
   "module": "lib/es/index.js",
   "author": "Jason Quense <monastic.panic@gmail.com>",
   "license": "MIT",
+  "scripts": {
+    "prepublishOnly": "mkdir lib && touch lib/build-output"
+  },
   "engines": {
     "node": ">= 8.3.0"
   },

--- a/packages/semantic-release-alt-publish-dir/test/prepare.test.js
+++ b/packages/semantic-release-alt-publish-dir/test/prepare.test.js
@@ -41,6 +41,8 @@ describe('Prepare', () => {
       version: '1.0.1',
     });
 
+    expect(fs.existsSync(`${dir}/lib/build-output`)).toEqual(true);
+
     expect(fs.existsSync(`${dir}/lib/README.md`)).toEqual(true);
 
     const libPkg = require(`${dir}/lib/package.json`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3995,6 +3995,7 @@ execa@^3.1.0, execa@^3.2.0, execa@^3.4.0:
 execa@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-4.0.0.tgz#7f37d6ec17f09e6b8fc53288611695b6d12b9daf"
+  integrity sha512-JbDUxwV3BoT5ZVXQrSVbAiaXhXUkIwvbhPIwZ0N13kX+5yCzOhUNdocxB/UQRuYOHRYYwAxKYwJYc0T4D12pDA==
   dependencies:
     cross-spawn "^7.0.0"
     get-stream "^5.0.0"


### PR DESCRIPTION
unclear what changed that broke this. I'm guessing the npm plugin used to do the lifecycle scripts earlier