### PR TITLE
fix: messagesDir in babel-plugin-react-intl is deprecated [WIP]

### DIFF
--- a/packages/babel-preset/index.js
+++ b/packages/babel-preset/index.js
@@ -223,7 +223,6 @@ function preset(api, explicitOptions = {}) {
         ? options.intl
         : {
             prefix: explicitOptions.prefix,
-            messagesDir: 'build/messages',
           };
 
     if (!development) {


### PR DESCRIPTION
`messagesDir` was removed in 8.0.0 https://github.com/formatjs/formatjs/blob/main/packages/babel-plugin-react-intl/CHANGELOG.md#800-2020-08-09

We need to shift this logic to formatjs/cli? Unsure of all the changes