### PR TITLE
chore: @babel/eslint-parser package moved from babel-eslint

### DIFF
--- a/packages/eslint-config-4catalyzer-typescript/index.js
+++ b/packages/eslint-config-4catalyzer-typescript/index.js
@@ -4,8 +4,8 @@ module.exports = {
     'import/parsers': {
       [require.resolve('@typescript-eslint/parser')]: ['.ts', '.tsx'],
       // needed for typescript files importing js, since the configured parser
-      // will be ts not babel-eslint for the host file
-      [require.resolve('babel-eslint')]: ['.js'],
+      // will be ts not @babel/eslint-parser for the host file
+      [require.resolve('@babel/eslint-parser')]: ['.js'],
     },
     'import/resolver': {
       node: {

--- a/packages/eslint-config-4catalyzer/index.js
+++ b/packages/eslint-config-4catalyzer/index.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: ['airbnb-base'],
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
   globals: {
     __DEV__: false,
   },


### PR DESCRIPTION
Depends on:
* [ ] https://github.com/4Catalyzer/javascript/pull/694

TODO:
* [ ] need a new release as this is blocking any eslint v8 updates I believe

Tested locally to be working