### PR TITLE
feat: add rule to ignore naming convention for properties that require quotes

### DIFF
--- a/packages/eslint-config-4catalyzer-typescript/rules.js
+++ b/packages/eslint-config-4catalyzer-typescript/rules.js
@@ -40,6 +40,20 @@ module.exports = {
   '@typescript-eslint/naming-convention': [
     'error',
     {
+      "selector": [
+        "classProperty",
+        "objectLiteralProperty",
+        "typeProperty",
+        "classMethod",
+        "objectLiteralMethod",
+        "typeMethod",
+        "accessor",
+        "enumMember"
+      ],
+      "format": null,
+      "modifiers": ["requiresQuotes"]
+    },
+    {
       selector: 'default',
       format: ['camelCase', 'PascalCase', 'UPPER_CASE'],
       leadingUnderscore: 'allow',


### PR DESCRIPTION
Started seeing `Object Literal Property name `Content-Type` must match one of the following formats: camelCase, PascalCase, UPPER_CASE`, etc.

Referenced from:
https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/naming-convention.md#ignore-properties-that-require-quotes