### PR TITLE
fix: don't set ignore file in default command

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "javascript",
   "scripts": {
-    "lint": "eslint packages --ignore-path .gitignore",
+    "lint": "eslint packages",
     "test": "npm run lint && lerna run test"
   },
   "gitHooks": {


### PR DESCRIPTION
Using the `.gitignore` file as an `.eslintignore` file causes some odd behavior, and there is no way to override it from a client usage. So just don't specify it in the root package